### PR TITLE
library: fix compiler warning when wchar_t is 16-bit

### DIFF
--- a/library/src/mipi_syst_api.c
+++ b/library/src/mipi_syst_api.c
@@ -936,7 +936,16 @@ static int buildPrintfPayload(
 					break;
 				case 'c':
 					if (modifier == MOD_L) {
+#if WCHAR_MAX == 0xFFFFU
+					  /*
+					   * Every va_arg has minimal size of 4 bytes.
+					   * Some arch has wchar_t to be 16-bit (2 bytes),
+					   * so promote to integer or else compiler will complain.
+					   */
+					  COPY_ARG32(mipi_syst_u32, int);
+#else
 					  COPY_ARG32(mipi_syst_u32, wchar_t);
+#endif
 					} else {
 					  COPY_ARG32(mipi_syst_u32, int);
 					}


### PR DESCRIPTION
Some architectures have wchar_t as 16-bit. So if you pass it
through printf() like functions, they are being promoted to
integer. However, the code to build Sys-T payload feeds
wchar_t to va_arg() which expects argument to be at least
the size of an integer, hence the warning:

```
  library/src/mipi_syst_api.c:947:34: warning: 'wchar_t' {aka 'short unsigned int'} is promoted to 'int' when passed through '...'
```

So fix it by promoting wchar_t to integer if needed.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>