### PR TITLE
library: Updating COPY_ARG_xxx() macros to use memcpy().

### DIFF
--- a/library/src/mipi_syst_api.c
+++ b/library/src/mipi_syst_api.c
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "mipi_syst.h"
 #include "mipi_syst/message.h"
+#include <limits.h>
 
 #if defined(MIPI_SYST_UNIT_TEST)
 #define ASSERT_CHECK(x) ASSERT_EQ(x, true)
@@ -938,7 +939,16 @@ static int buildPrintfPayload(
 					break;
 				case 'c':
 					if (modifier == MOD_L) {
+#if WCHAR_MAX == 0xFFFFU
+					  /*
+					   * Every va_arg has minimal size of 4 bytes.
+					   * Some arch has wchar_t to be 16-bit (2 bytes),
+					   * so promote to integer or else compiler will complain.
+					   */
+					  COPY_ARG32(mipi_syst_u32, int);
+#else
 					  COPY_ARG32(mipi_syst_u32, wchar_t);
+#endif
 					} else {
 					  COPY_ARG32(mipi_syst_u32, int);
 					}

--- a/library/src/mipi_syst_api.c
+++ b/library/src/mipi_syst_api.c
@@ -651,7 +651,7 @@ enum ReturnCodes {
     val.d = (TOTYPE)va_arg(args, FROMTYPE);				\
     if (argp + sizeof(TOTYPE) < argEob) {				\
       val.v = MIPI_SYST_HTOLE64(val.v);					\
-      *((TOTYPE *)argp) = val.d;					\
+      memcpy(argp, &val.d, sizeof(TOTYPE));				\
       argp += sizeof(TOTYPE);						\
     } else {								\
       return FMT_PARSE_ARG_BUFFER_TOO_SMALL;				\
@@ -661,7 +661,8 @@ enum ReturnCodes {
 #define COPY_ARG32(TOTYPE, FROMTYPE)					\
   do {									\
     if (argp + sizeof(TOTYPE) < argEob) {				\
-      *((TOTYPE *)argp) = (TOTYPE)MIPI_SYST_HTOLE32(va_arg(args, FROMTYPE)); \
+      TOTYPE val = (TOTYPE)MIPI_SYST_HTOLE32(va_arg(args, FROMTYPE)); \
+      memcpy(argp, &val, sizeof(TOTYPE));				\
       argp += sizeof(TOTYPE);						\
     } else {								\
       return FMT_PARSE_ARG_BUFFER_TOO_SMALL;				\
@@ -671,7 +672,8 @@ enum ReturnCodes {
 #define COPY_ARG64(TOTYPE, FROMTYPE)					\
   do {									\
     if (argp + sizeof(TOTYPE) < argEob) {				\
-      *((TOTYPE *)argp) = (TOTYPE)MIPI_SYST_HTOLE64(va_arg(args, FROMTYPE));\
+      TOTYPE val = (TOTYPE)MIPI_SYST_HTOLE64(va_arg(args, FROMTYPE)); \
+      memcpy(argp, &val, sizeof(TOTYPE));				\
       argp += sizeof(TOTYPE);						\
     } else {								\
       return FMT_PARSE_ARG_BUFFER_TOO_SMALL;				\


### PR DESCRIPTION
There are memory alignment issues across architectures, hence
Updating COPY_ARG_xxx() macros to use memcpy() to avoid
failures caused by memory alignment.

Signed-off-by: Aastha Grover <aastha.grover@intel.com>