### PR TITLE
Kconfig: Add user configurable ARG_BUFFER_SIZE option.

### DIFF
--- a/library/include/mipi_syst.h.in
+++ b/library/include/mipi_syst.h.in
@@ -523,14 +523,6 @@ typedef void (*mipi_syst_msg_write_t)(
 
 #define MIPI_SYST_PCFG_ENABLE_PRINTF_API
 
-/**
- * Maximum size of printf payload in bytes.
- * Adjust this value if larger strings shall be supported by the library.
- * The buffer space is located in stack memory when calling one of the printf
- * style APIs.
- */
-#define MIPI_SYST_PCFG_PRINTF_ARGBUF_SIZE 1024
-
 #endif /* #if MIPI_SYST_CONFORMANCE_LEVEL > 20 */
 
 /* @} */
@@ -598,6 +590,17 @@ typedef void (*mipi_syst_msg_write_t)(
 /** @} */
 
 #include "mipi_syst/platform.h"
+
+/**
+ * Maximum size of printf payload in bytes.
+ * Adjust this value if larger strings shall be supported by the library.
+ * The buffer space is located in stack memory when calling one of the printf
+ * style APIs.
+ */
+#if !defined(MIPI_SYST_PCFG_PRINTF_ARGBUF_SIZE)
+#define MIPI_SYST_PCFG_PRINTF_ARGBUF_SIZE 1024
+#endif
+
 #endif
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Change MIPI_SYST_PCFG_PRINTF_ARGBUF_SIZE macro to get the value
from user configurable CONFIG_LOG_MIPI_SYST_ARGS_BUFFER_SIZE
Kconfig option which defaults to 1kb.
CONFIG_LOG_MIPI_SYST_ARGS_BUFFER_SIZE would give flexibility to
users when maximum log length is known.
For more details see zephyrproject-rtos/zephyr#48839

Fixes #10

Signed-off-by: Aastha Grover <aastha.grover@intel.com>