### PR TITLE
library: allow building without wchar support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,4 +34,8 @@ if(CONFIG_MIPI_SYST_LIB)
     zephyr_library_link_libraries(mipi_syst_library)
 
     target_link_libraries(mipi_syst_library INTERFACE zephyr_interface)
+
+    if(CONFIG_MIPI_SYST_NO_WHCAR)
+      zephyr_library_compile_definitions(NO_WCHAR)
+    endif()
 endif()

--- a/library/src/mipi_syst_api.c
+++ b/library/src/mipi_syst_api.c
@@ -604,7 +604,10 @@ mipi_syst_write_clock(struct mipi_syst_handle* svh,
 
 #include <stdarg.h>
 #include <stddef.h>
+
+#ifndef NO_WCHAR
 #include <wchar.h>
+#endif
 
 #if !defined(MIPI_SYST_PCFG_PRINTF_ARGBUF_SIZE)
 #define MIPI_SYST_PCFG_PRINTF_ARGBUF_SIZE 1024  /* Default 1Kb arg buffer */
@@ -1059,7 +1062,11 @@ static int buildCatalogPayload(
 			COPY_ARG32(mipi_syst_u32, int);
 			break;
 		case _MIPI_SYST_CATARG_LC:
+#if defined(_WCHAR_H) && (_WCHAR_H == 1)
 			COPY_ARG32(mipi_syst_u32, wint_t);
+#else
+			COPY_ARG32(mipi_syst_u32, unsigned int);
+#endif
 			break;
 
 		case _MIPI_SYST_CATARG_P:


### PR DESCRIPTION
This allows grabbing a config from  Zephyr to specify whether wchar is supported (i.e. including wchar.h). Zephyr minimal C library doesn't have wchar support and we probably won't need it either.